### PR TITLE
Change cert validity to duration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ mockgen:
 	GO111MODULE=on go get -v github.com/golang/mock/mockgen@latest
 
 test: generate
-	go test -v -race ./... -count=1 -coverprofile cover.out
+	go test -v -timeout 300s -race ./... -count=1 -coverprofile cover.out
 
 update-diagrams:
 	$(MMD_CMD) -i $(COMPOSITE_CONTROLLER_DIR)/docs/create.mmd -o $(COMPOSITE_CONTROLLER_DIR)/docs/create.svg

--- a/webhook/cert/manager.go
+++ b/webhook/cert/manager.go
@@ -101,11 +101,11 @@ type Options struct {
 	// KeyName is the server key name. Defaults to tls.key.
 	KeyName string
 
-	// CertValidity is the validity of the generated certificate. This is not
+	// CertValidity is the length of the generated certificate's validity. This is not
 	// the validity of the root CA cert. That's set to 10 years by default in
 	// the client-go cert utils package.
 	// If not set, this defaults to a year.
-	CertValidity time.Time
+	CertValidity time.Duration
 }
 
 // setDefault sets the default options.

--- a/webhook/cert/manager_test.go
+++ b/webhook/cert/manager_test.go
@@ -73,7 +73,7 @@ func TestManager(t *testing.T) {
 		SecretRef:                   &types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace},
 		MutatingWebhookConfigRefs:   []types.NamespacedName{{Name: mutatingWebhookConfig.Name}},
 		ValidatingWebhookConfigRefs: []types.NamespacedName{{Name: validatingWebhookConfig.Name}},
-		CertValidity:                time.Now().AddDate(0, 0, 1),
+		CertValidity:                24 * time.Hour,
 	}
 
 	// Create a new cert manager.
@@ -179,24 +179,22 @@ func TestMultipleManagers(t *testing.T) {
 }
 
 func TestOptionsSetDefault(t *testing.T) {
-	testcases := []struct {
+	testcases := map[string]struct {
 		name      string
 		inputOpts Options
 		wantOpts  Options
 	}{
-		{
-			name:      "empty",
+		"empty": {
 			inputOpts: Options{},
 			wantOpts: Options{
 				Port:                int32(webhook.DefaultPort),
-				CertDir:             "/tmp/k8s-webhook-server/serving-certs",
+				CertDir:             os.TempDir() + "/k8s-webhook-server/serving-certs",
 				CertName:            "tls.crt",
 				KeyName:             "tls.key",
 				CertRefreshInterval: 30 * time.Minute,
 			},
 		},
-		{
-			name: "custom",
+		"custom": {
 			inputOpts: Options{
 				Port:                int32(2222),
 				CertDir:             "/tmp/foo",
@@ -214,9 +212,9 @@ func TestOptionsSetDefault(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testcases {
+	for name, tc := range testcases {
 		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			// Take a copy of the input.
 			resultOpts := tc.inputOpts
 


### PR DESCRIPTION
Concrete time of a certificate validity makes the implementation a bit risky on case of long running operators with short living certificates. Operator is able to overtake the certificate validity which should break the operator. This change replaces time to duration and calculates validity from the time of the generation.