### PR TITLE
Unify native and custom resource admission controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,13 @@ enable telemetry in an operator.
 
 #### webhook
 
-`webhook/cert` package provides a local certificate manager that can provision
-self signed certificate for webhook server, backed by k8s secret for
-persistence, and refresh certificate when they expire automatically.
+- `webhook/cert` package provides a local certificate manager that can provision
+    self signed certificate for webhook server, backed by k8s secret for
+    persistence, and refresh certificate when they expire automatically.
+
+- `webhook/admission` package provides a consistent way of building admission
+    controllers for k8s native and custom resources with function chaining
+    support.
 
 The above packages can be used together or independently of each other.
 `example/` contains an example of using all the packages together in a

--- a/example/api/v1alpha1/game_webhook.go
+++ b/example/api/v1alpha1/game_webhook.go
@@ -35,6 +35,7 @@ func (r *Game) SetupWebhookWithManager(mgr ctrl.Manager) error {
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 
 //+kubebuilder:webhook:path=/mutate-app-example-com-v1alpha1-game,mutating=true,failurePolicy=fail,sideEffects=None,groups=app.example.com,resources=games,verbs=create;update,versions=v1alpha1,name=mgame.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-configmap,mutating=true,failurePolicy=fail,sideEffects=None,groups="",resources=configmaps,verbs=create;update,versions=v1,name=mconfigmap.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &Game{}
 
@@ -47,6 +48,7 @@ func (r *Game) Default() {
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 //+kubebuilder:webhook:path=/validate-app-example-com-v1alpha1-game,mutating=false,failurePolicy=fail,sideEffects=None,groups=app.example.com,resources=games,verbs=create;update,versions=v1alpha1,name=vgame.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-configmap,mutating=false,failurePolicy=fail,sideEffects=None,groups="",resources=configmaps,verbs=create;update;delete,versions=v1,name=vconfigmap.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &Game{}
 

--- a/example/config/webhook/manifests.yaml
+++ b/example/config/webhook/manifests.yaml
@@ -27,6 +27,27 @@ webhooks:
     resources:
     - games
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-configmap
+  failurePolicy: Fail
+  name: mconfigmap.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - configmaps
+  sideEffects: None
 
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -55,4 +76,26 @@ webhooks:
     - UPDATE
     resources:
     - games
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-configmap
+  failurePolicy: Fail
+  name: vconfigmap.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - configmaps
   sideEffects: None

--- a/example/controllers/configmap_admission_controller.go
+++ b/example/controllers/configmap_admission_controller.go
@@ -1,0 +1,88 @@
+package controllers
+
+import (
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/discovery"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	tkadmission "github.com/darkowlzz/operator-toolkit/webhook/admission"
+	"github.com/darkowlzz/operator-toolkit/webhook/builder"
+	"github.com/darkowlzz/operator-toolkit/webhook/function"
+)
+
+type ConfigMapAdmissionController struct {
+	CtrlName        string
+	Log             logr.Logger
+	Client          client.Client
+	DiscoveryClient discovery.DiscoveryInterface
+}
+
+var _ tkadmission.Controller = &ConfigMapAdmissionController{}
+
+var validLabels = map[string]string{
+	"valid-key-1": "some-val1",
+	"valid-key-2": "some-val2",
+	"foo":         "baz",
+}
+
+func NewConfigMapAdmissionController(name string, cli client.Client, dc discovery.DiscoveryInterface, log logr.Logger) *ConfigMapAdmissionController {
+	return &ConfigMapAdmissionController{
+		CtrlName:        name,
+		Log:             log,
+		Client:          cli,
+		DiscoveryClient: dc,
+	}
+}
+
+func (cmac *ConfigMapAdmissionController) Name() string {
+	return cmac.CtrlName
+}
+
+func (cmac *ConfigMapAdmissionController) GetNewObject() client.Object {
+	return &corev1.ConfigMap{}
+}
+
+func (cmac *ConfigMapAdmissionController) RequireDefaulting(obj client.Object) bool {
+	// Perform any relevant checks to determine if the object should be
+	// defaulted or ignored.
+	return true
+}
+
+func (cmac *ConfigMapAdmissionController) RequireValidating(obj client.Object) bool {
+	// Perform any relevant checks to determine if the object should be
+	// validated or ignored.
+	return true
+}
+
+func (cmac *ConfigMapAdmissionController) Default() []tkadmission.DefaultFunc {
+	return []tkadmission.DefaultFunc{
+		function.AddLabels(cmac.Client, map[string]string{"foo": "bar"}),
+		function.AddAnnotations(cmac.Client, map[string]string{"zzz": "qqqq"}),
+		function.AddClusterVersionAnnotation(cmac.DiscoveryClient),
+	}
+}
+
+func (cmac *ConfigMapAdmissionController) ValidateCreate() []tkadmission.ValidateCreateFunc {
+	return []tkadmission.ValidateCreateFunc{
+		function.ValidateLabelsCreate(validLabels),
+	}
+}
+
+func (cmac *ConfigMapAdmissionController) ValidateUpdate() []tkadmission.ValidateUpdateFunc {
+	return []tkadmission.ValidateUpdateFunc{
+		function.ValidateLabelsUpdate(validLabels),
+	}
+}
+
+func (cmac *ConfigMapAdmissionController) ValidateDelete() []tkadmission.ValidateDeleteFunc {
+	return []tkadmission.ValidateDeleteFunc{}
+}
+
+func (cmac *ConfigMapAdmissionController) SetupWithManager(mgr manager.Manager) error {
+	return builder.WebhookManagedBy(mgr).
+		MutatePath("/mutate-configmap").
+		ValidatePath("/validate-configmap").
+		Complete(cmac)
+}

--- a/example/go.sum
+++ b/example/go.sum
@@ -117,6 +117,7 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bombsimon/wsl v1.2.5/go.mod h1:43lEF/i0kpXbLCeDXL9LMT8c92HyBywXb0AsgMHYngM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/webhook/admission/controller.go
+++ b/webhook/admission/controller.go
@@ -1,0 +1,18 @@
+package admission
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+// Controller defines an interface for a webhook admission controller.
+type Controller interface {
+	// Name returns the name of the controller.
+	Name() string
+	Defaulter
+	Validator
+}
+
+// ObjectGetter defines an interface for getting an object of any type,
+// depending on the controller's target object type, in a generic form.
+type ObjectGetter interface {
+	// GetNewObject returns a new initialized object of the target object type.
+	GetNewObject() client.Object
+}

--- a/webhook/admission/defaulter.go
+++ b/webhook/admission/defaulter.go
@@ -1,0 +1,88 @@
+package admission
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// DefaultFunc is a function in the defaulting function chain, which forms a
+// defaulter pipeline.
+type DefaultFunc func(ctx context.Context, obj client.Object)
+
+// Defaulter defines functions for setting defaults on resource.
+type Defaulter interface {
+	// ObjectGetter returns a new instance of the target object type of the
+	// defaulter.
+	ObjectGetter
+	// Default returns a list of default functions that form the defaulting
+	// pipeline.
+	Default() []DefaultFunc
+	// RequireDefaulting can be used to perform a check before processing the
+	// request object and decide if defaulting is required or the object can be
+	// ignore. Default() will not be called if this returns false. In case of
+	// any error, true can be returned and a similar check can be performed in
+	// a defaulting function that can return the proper error message that'll
+	// be propagated to the user.
+	RequireDefaulting(obj client.Object) bool
+}
+
+// DefaultingWebhookFor creates a new webhook for Defaulting the provided
+// object type.
+func DefaultingWebhookFor(defaulter Defaulter) *admission.Webhook {
+	return &admission.Webhook{
+		Handler: &mutatingHandler{defaulter: defaulter},
+	}
+}
+
+type mutatingHandler struct {
+	defaulter Defaulter
+	decoder   *admission.Decoder
+}
+
+var _ admission.DecoderInjector = &mutatingHandler{}
+
+// InjectDecoder injects the decoder into a mutatingHandler.
+func (h *mutatingHandler) InjectDecoder(d *admission.Decoder) error {
+	h.decoder = d
+	return nil
+}
+
+// Handle handles admission requests.
+func (h *mutatingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if h.defaulter == nil {
+		panic("defaulter should never be nil")
+	}
+
+	// Obtain a new object of the target type to decode the request object.
+	obj := h.defaulter.GetNewObject()
+
+	// Add namespace info into the object. The webhook payload only contains
+	// runtime.Object without any metadata info.
+	obj.SetNamespace(req.AdmissionRequest.Namespace)
+
+	// Get the object in the request.
+	err := h.decoder.Decode(req, obj)
+	if err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	// Run the defaulters only if defaulting is required.
+	if h.defaulter.RequireDefaulting(obj) {
+		// Process the object through the defaulting pipeline.
+		for _, m := range h.defaulter.Default() {
+			m(ctx, obj)
+		}
+	}
+
+	marshalled, err := json.Marshal(obj)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	// Create the patch
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshalled)
+}

--- a/webhook/admission/defaulter_test.go
+++ b/webhook/admission/defaulter_test.go
@@ -1,0 +1,190 @@
+package admission
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	appv1alpha1 "github.com/darkowlzz/operator-toolkit/testdata/api/v1alpha1"
+)
+
+var _ = Describe("Defaulter Webhooks", func() {
+
+	err := appv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	decoder, _ := admission.NewDecoder(scheme.Scheme)
+
+	Context("when there's no defaulting function and the target object is a native resource", func() {
+		f := &fakeMutator{
+			RequireDefaultingToReturn: true,
+			NewObject:                 &corev1.ConfigMap{},
+		}
+
+		handler := mutatingHandler{defaulter: f, decoder: decoder}
+
+		It("should succeed", func() {
+			response := handler.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.defaulter.GetNewObject(),
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeTrue())
+		})
+	})
+
+	Context("when the target object is a custom resource", func() {
+		f := &fakeMutator{
+			RequireDefaultingToReturn: true,
+			NewObject:                 &appv1alpha1.Game{},
+		}
+
+		handler := mutatingHandler{defaulter: f, decoder: decoder}
+
+		It("should succeed", func() {
+			response := handler.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.defaulter.GetNewObject(),
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeTrue())
+		})
+	})
+
+	Context("when the defaulting functions are chained", func() {
+		defFunc1 := fakeDefaultFunc{}
+		defFunc2 := fakeDefaultFunc{}
+		defFunc3 := fakeDefaultFunc{}
+
+		f := &fakeMutator{
+			RequireDefaultingToReturn: true,
+			NewObject:                 &corev1.ConfigMap{},
+			DefaultFuncs: []DefaultFunc{
+				defFunc1.MutateFunc(),
+				defFunc2.MutateFunc(),
+				defFunc3.MutateFunc(),
+			},
+		}
+
+		handler := mutatingHandler{defaulter: f, decoder: decoder}
+
+		BeforeEach(func() {
+			// Reset all the defaulting funcs.
+			defFunc1.Reset()
+			defFunc2.Reset()
+			defFunc3.Reset()
+		})
+
+		It("should call all the chained functions", func() {
+			response := handler.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.defaulter.GetNewObject(),
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeTrue())
+
+			callCount := defFunc1.Count() + defFunc2.Count() + defFunc3.Count()
+			Expect(callCount).Should(Equal(3))
+		})
+	})
+
+	Context("when require defaulting returns false", func() {
+		defFunc1 := fakeDefaultFunc{}
+		defFunc2 := fakeDefaultFunc{}
+		defFunc3 := fakeDefaultFunc{}
+
+		f := &fakeMutator{
+			RequireDefaultingToReturn: false,
+			NewObject:                 &corev1.ConfigMap{},
+			DefaultFuncs: []DefaultFunc{
+				defFunc1.MutateFunc(),
+				defFunc2.MutateFunc(),
+				defFunc3.MutateFunc(),
+			},
+		}
+
+		handler := mutatingHandler{defaulter: f, decoder: decoder}
+
+		BeforeEach(func() {
+			// Reset all the defaulting funcs.
+			defFunc1.Reset()
+			defFunc2.Reset()
+			defFunc3.Reset()
+		})
+
+		It("should not call the chained functions", func() {
+			response := handler.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.defaulter.GetNewObject(),
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeTrue())
+
+			callCount := defFunc1.Count() + defFunc2.Count() + defFunc3.Count()
+			Expect(callCount).Should(Equal(0))
+		})
+	})
+})
+
+type fakeMutator struct {
+	DefaultFuncs              []DefaultFunc
+	RequireDefaultingToReturn bool
+	NewObject                 client.Object
+}
+
+var _ Defaulter = &fakeMutator{}
+
+func (m *fakeMutator) Default() []DefaultFunc {
+	return m.DefaultFuncs
+}
+
+func (m *fakeMutator) RequireDefaulting(obj client.Object) bool {
+	return m.RequireDefaultingToReturn
+}
+
+func (m *fakeMutator) GetNewObject() client.Object {
+	return m.NewObject
+}
+
+// fakeDefaultFunc is a fake default function with a call counter.
+type fakeDefaultFunc struct {
+	callCount int
+}
+
+func (f *fakeDefaultFunc) MutateFunc() DefaultFunc {
+	return func(ctx context.Context, obj client.Object) {
+		f.callCount++
+	}
+}
+
+func (f *fakeDefaultFunc) Count() int {
+	return f.callCount
+}
+
+func (f *fakeDefaultFunc) Reset() {
+	f.callCount = 0
+}

--- a/webhook/admission/doc.go
+++ b/webhook/admission/doc.go
@@ -1,0 +1,10 @@
+// Package admission provides interfaces for building admission controllers
+// with chaining function with support for both k8s native and custom resources
+// in a consistent way. It's based on the custom resource admission webhook
+// from controller-runtime, modified to not be specific to custom resources
+// only. The defaulter and validator can have multiple functions, chained
+// together to form a processing pipeline. They also have the ability to
+// perform checks in advance before passing the object to the processing
+// pipeline to avoid repetitive checks in each of the functions for filtering
+// the objects and ignoring if needed.
+package admission

--- a/webhook/admission/suite_test.go
+++ b/webhook/admission/suite_test.go
@@ -1,0 +1,26 @@
+package admission
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestAdmissionWebhook(t *testing.T) {
+	RegisterFailHandler(Fail)
+	suiteName := "Admission Webhook Suite"
+	RunSpecsWithDefaultAndCustomReporters(t,
+		suiteName,
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	close(done)
+}, 60)

--- a/webhook/admission/validator.go
+++ b/webhook/admission/validator.go
@@ -1,0 +1,156 @@
+package admission
+
+import (
+	"context"
+	goerrors "errors"
+	"net/http"
+
+	v1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// Validate-Funcs are functions in validating function chain, which forms a
+// validating pipeline for a type of operation.
+type ValidateCreateFunc func(ctx context.Context, obj client.Object) error
+type ValidateUpdateFunc func(ctx context.Context, obj client.Object, old client.Object) error
+type ValidateDeleteFunc func(ctx context.Context, obj client.Object) error
+
+// Validator defines functions for validating an operation.
+type Validator interface {
+	// ObjectGetter returns a new instance of the target object type of the
+	// defaulter.
+	ObjectGetter
+	// ValidateCreate returns a list of validate functions for create event.
+	ValidateCreate() []ValidateCreateFunc
+	// ValidateCreate returns a list of validate functions for update event.
+	ValidateUpdate() []ValidateUpdateFunc
+	// ValidateCreate returns a list of validate functions for delete event.
+	ValidateDelete() []ValidateDeleteFunc
+	// RequireValidating can be used to perform a check before processing the
+	// request object and decide if validating is required or the object can be
+	// ignored. None of the validating functions will be called if this returns
+	// false. In case of any error, true can be returned and a similar check
+	// can be performed in a validate function that can return the proper error
+	// message that'll be propogated to the user.
+	RequireValidating(obj client.Object) bool
+}
+
+// ValidatingWebhookFor creates a new Webhook for validating the provided
+// object type.
+func ValidatingWebhookFor(validator Validator) *admission.Webhook {
+	return &admission.Webhook{
+		Handler: &validatingHandler{validator: validator},
+	}
+}
+
+type validatingHandler struct {
+	validator Validator
+	decoder   *admission.Decoder
+}
+
+var _ admission.DecoderInjector = &validatingHandler{}
+
+// InjectDecoder injects the decoder into a validatingHandler.
+func (h *validatingHandler) InjectDecoder(d *admission.Decoder) error {
+	h.decoder = d
+	return nil
+}
+
+// Handle handles admission requests.
+func (h *validatingHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if h.validator == nil {
+		panic("validator should never be nil")
+	}
+
+	// Obtain a new object of the target type to decode the request object.
+	obj := h.validator.GetNewObject()
+
+	// Add namespace info into the object. The webhook payload only contains
+	// runtime.Object without any metadata info.
+	obj.SetNamespace(req.AdmissionRequest.Namespace)
+
+	if req.Operation == v1.Create {
+		// Get the object in the request.
+		err := h.decoder.Decode(req, obj)
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		// Run the validations only if validation is required.
+		if h.validator.RequireValidating(obj) {
+			for _, m := range h.validator.ValidateCreate() {
+				if err := m(ctx, obj); err != nil {
+					var apiStatus errors.APIStatus
+					if goerrors.As(err, &apiStatus) {
+						return validationResponseFromStatus(false, apiStatus.Status())
+					}
+					return admission.Denied(err.Error())
+				}
+			}
+		}
+	}
+
+	if req.Operation == v1.Update {
+		oldObj := h.validator.GetNewObject()
+
+		err := h.decoder.DecodeRaw(req.Object, obj)
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		err = h.decoder.DecodeRaw(req.OldObject, oldObj)
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		// Run the validations only if validation is required.
+		if h.validator.RequireValidating(obj) {
+			for _, m := range h.validator.ValidateUpdate() {
+				if err := m(ctx, obj, oldObj); err != nil {
+					var apiStatus errors.APIStatus
+					if goerrors.As(err, &apiStatus) {
+						return validationResponseFromStatus(false, apiStatus.Status())
+					}
+					return admission.Denied(err.Error())
+				}
+			}
+		}
+	}
+
+	if req.Operation == v1.Delete {
+		// In reference to PR: https://github.com/kubernetes/kubernetes/pull/76346
+		// OldObject contains the object being deleted
+		err := h.decoder.DecodeRaw(req.OldObject, obj)
+		if err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		// Run the validations only if validation is required.
+		if h.validator.RequireValidating(obj) {
+			for _, m := range h.validator.ValidateDelete() {
+				if err := m(ctx, obj); err != nil {
+					var apiStatus errors.APIStatus
+					if goerrors.As(err, &apiStatus) {
+						return validationResponseFromStatus(false, apiStatus.Status())
+					}
+					return admission.Denied(err.Error())
+				}
+			}
+		}
+	}
+
+	return admission.Allowed("")
+}
+
+// validationResponseFromStatus returns a response for admitting a request with provided Status object.
+func validationResponseFromStatus(allowed bool, status metav1.Status) admission.Response {
+	resp := admission.Response{
+		AdmissionResponse: v1.AdmissionResponse{
+			Allowed: allowed,
+			Result:  &status,
+		},
+	}
+	return resp
+}

--- a/webhook/admission/validator_test.go
+++ b/webhook/admission/validator_test.go
@@ -1,0 +1,477 @@
+package admission
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	appv1alpha1 "github.com/darkowlzz/operator-toolkit/testdata/api/v1alpha1"
+)
+
+var _ = Describe("Validating Webhooks", func() {
+
+	err := appv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	decoder, _ := admission.NewDecoder(scheme.Scheme)
+
+	Context("when there's no validating function and target object is a native resource", func() {
+		f := &fakeValidator{
+			RequireValidityToReturn: true,
+			NewObject:               &corev1.ConfigMap{},
+		}
+
+		handler := validatingHandler{validator: f, decoder: decoder}
+
+		It("should return 200 in response when create succeeds", func() {
+			response := handler.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator.GetNewObject(),
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeTrue())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
+		})
+
+		It("should return 200 in response when update succeeds", func() {
+			response := handler.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
+					Object: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator.GetNewObject(),
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator.GetNewObject(),
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeTrue())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
+		})
+
+		It("should return 200 in response when delete succeeds", func() {
+			response := handler.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator.GetNewObject(),
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeTrue())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
+		})
+	})
+
+	Context("when the target object is a custom resource", func() {
+		f := &fakeValidator{
+			RequireValidityToReturn: true,
+			NewObject:               &appv1alpha1.Game{},
+		}
+
+		handler := validatingHandler{validator: f, decoder: decoder}
+
+		It("should return 200 in response when create succeeds", func() {
+			response := handler.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator.GetNewObject(),
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeTrue())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
+		})
+
+		It("should return 200 in response when update succeeds", func() {
+			response := handler.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
+					Object: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator.GetNewObject(),
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator.GetNewObject(),
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeTrue())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
+		})
+
+		It("should return 200 in response when delete succeeds", func() {
+			response := handler.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator.GetNewObject(),
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeTrue())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
+		})
+	})
+
+	Context("when validating functions are chained, no error", func() {
+		// Create validate functions to chain together.
+		validateFunc1 := fakeValidateFunc{ErrorToReturn: nil}
+		validateFunc2 := fakeValidateFunc{ErrorToReturn: nil}
+		validateFunc3 := fakeValidateFunc{ErrorToReturn: nil}
+
+		f := &fakeValidator{
+			RequireValidityToReturn: true,
+			NewObject:               &corev1.ConfigMap{},
+			CreateFuncs: []ValidateCreateFunc{
+				validateFunc1.CreateFunc(),
+				validateFunc2.CreateFunc(),
+				validateFunc3.CreateFunc(),
+			},
+			UpdateFuncs: []ValidateUpdateFunc{
+				validateFunc1.UpdateFunc(),
+				validateFunc2.UpdateFunc(),
+				validateFunc3.UpdateFunc(),
+			},
+			DeleteFuncs: []ValidateDeleteFunc{
+				validateFunc1.DeleteFunc(),
+				validateFunc2.DeleteFunc(),
+				validateFunc3.DeleteFunc(),
+			},
+		}
+
+		handler := validatingHandler{validator: f, decoder: decoder}
+
+		BeforeEach(func() {
+			// Reset all the validate funcs.
+			validateFunc1.Reset()
+			validateFunc2.Reset()
+			validateFunc3.Reset()
+		})
+
+		It("should call all the chained functions in response to create request", func() {
+			response := handler.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator.GetNewObject(),
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeTrue())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
+
+			callCount := validateFunc1.Count() + validateFunc2.Count() + validateFunc3.Count()
+			Expect(callCount).Should(Equal(3))
+		})
+
+		It("should call all the chained functions in response to update request", func() {
+			response := handler.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
+					Object: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator.GetNewObject(),
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator.GetNewObject(),
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeTrue())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
+
+			callCount := validateFunc1.Count() + validateFunc2.Count() + validateFunc3.Count()
+			Expect(callCount).Should(Equal(3))
+		})
+
+		It("should call all the chained functions in response to delete request", func() {
+			response := handler.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator.GetNewObject(),
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeTrue())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
+
+			callCount := validateFunc1.Count() + validateFunc2.Count() + validateFunc3.Count()
+			Expect(callCount).Should(Equal(3))
+		})
+	})
+
+	Context("when validating functions return error", func() {
+		// Create validate functions to chain together.
+		validateFunc1 := fakeValidateFunc{ErrorToReturn: nil}
+		validateFunc2 := fakeValidateFunc{ErrorToReturn: fmt.Errorf("fake error")}
+		validateFunc3 := fakeValidateFunc{ErrorToReturn: nil}
+
+		f := &fakeValidator{
+			RequireValidityToReturn: true,
+			NewObject:               &corev1.ConfigMap{},
+			CreateFuncs: []ValidateCreateFunc{
+				validateFunc1.CreateFunc(),
+				validateFunc2.CreateFunc(),
+				validateFunc3.CreateFunc(),
+			},
+			UpdateFuncs: []ValidateUpdateFunc{
+				validateFunc1.UpdateFunc(),
+				validateFunc2.UpdateFunc(),
+				validateFunc3.UpdateFunc(),
+			},
+			DeleteFuncs: []ValidateDeleteFunc{
+				validateFunc1.DeleteFunc(),
+				validateFunc2.DeleteFunc(),
+				validateFunc3.DeleteFunc(),
+			},
+		}
+
+		handler := validatingHandler{validator: f, decoder: decoder}
+
+		BeforeEach(func() {
+			// Reset all the validate funcs.
+			validateFunc1.Reset()
+			validateFunc2.Reset()
+			validateFunc3.Reset()
+		})
+
+		It("should not call all the chained functions in response to create request", func() {
+			response := handler.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator.GetNewObject(),
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeFalse())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusForbidden)))
+
+			callCount := validateFunc1.Count() + validateFunc2.Count() + validateFunc3.Count()
+			Expect(callCount).ShouldNot(Equal(3))
+		})
+
+		It("should not call all the chained functions in response to update request", func() {
+			response := handler.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
+					Object: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator.GetNewObject(),
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator.GetNewObject(),
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeFalse())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusForbidden)))
+
+			callCount := validateFunc1.Count() + validateFunc2.Count() + validateFunc3.Count()
+			Expect(callCount).ShouldNot(Equal(3))
+		})
+
+		It("should not call all the chained functions in response to delete request", func() {
+			response := handler.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator.GetNewObject(),
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeFalse())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusForbidden)))
+
+			callCount := validateFunc1.Count() + validateFunc2.Count() + validateFunc3.Count()
+			Expect(callCount).ShouldNot(Equal(3))
+		})
+	})
+
+	Context("when require validating returns false", func() {
+		// Create validate functions to chain together.
+		validateFunc1 := fakeValidateFunc{ErrorToReturn: nil}
+		validateFunc2 := fakeValidateFunc{ErrorToReturn: nil}
+		validateFunc3 := fakeValidateFunc{ErrorToReturn: nil}
+
+		f := &fakeValidator{
+			RequireValidityToReturn: false,
+			NewObject:               &corev1.ConfigMap{},
+			CreateFuncs: []ValidateCreateFunc{
+				validateFunc1.CreateFunc(),
+				validateFunc2.CreateFunc(),
+				validateFunc3.CreateFunc(),
+			},
+			UpdateFuncs: []ValidateUpdateFunc{
+				validateFunc1.UpdateFunc(),
+				validateFunc2.UpdateFunc(),
+				validateFunc3.UpdateFunc(),
+			},
+			DeleteFuncs: []ValidateDeleteFunc{
+				validateFunc1.DeleteFunc(),
+				validateFunc2.DeleteFunc(),
+				validateFunc3.DeleteFunc(),
+			},
+		}
+
+		handler := validatingHandler{validator: f, decoder: decoder}
+
+		BeforeEach(func() {
+			// Reset all the validate funcs.
+			validateFunc1.Reset()
+			validateFunc2.Reset()
+			validateFunc3.Reset()
+		})
+
+		It("should not call chained functions in response to create request", func() {
+			response := handler.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					Object: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator.GetNewObject(),
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeTrue())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
+
+			callCount := validateFunc1.Count() + validateFunc2.Count() + validateFunc3.Count()
+			Expect(callCount).Should(Equal(0))
+		})
+
+		It("should not call chained functions in response to update request", func() {
+			response := handler.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
+					Object: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator.GetNewObject(),
+					},
+					OldObject: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator.GetNewObject(),
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeTrue())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
+
+			callCount := validateFunc1.Count() + validateFunc2.Count() + validateFunc3.Count()
+			Expect(callCount).Should(Equal(0))
+		})
+
+		It("should not call chained functions in response to delete request", func() {
+			response := handler.Handle(context.TODO(), admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator.GetNewObject(),
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeTrue())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
+
+			callCount := validateFunc1.Count() + validateFunc2.Count() + validateFunc3.Count()
+			Expect(callCount).Should(Equal(0))
+		})
+	})
+})
+
+type fakeValidator struct {
+	CreateFuncs             []ValidateCreateFunc
+	UpdateFuncs             []ValidateUpdateFunc
+	DeleteFuncs             []ValidateDeleteFunc
+	RequireValidityToReturn bool
+	NewObject               client.Object
+}
+
+var _ Validator = &fakeValidator{}
+
+func (v *fakeValidator) ValidateCreate() []ValidateCreateFunc {
+	return v.CreateFuncs
+}
+
+func (v *fakeValidator) ValidateUpdate() []ValidateUpdateFunc {
+	return v.UpdateFuncs
+}
+
+func (v *fakeValidator) ValidateDelete() []ValidateDeleteFunc {
+	return v.DeleteFuncs
+}
+
+func (v *fakeValidator) RequireValidating(obj client.Object) bool {
+	return v.RequireValidityToReturn
+}
+
+func (v *fakeValidator) GetNewObject() client.Object {
+	return v.NewObject
+}
+
+// fakeValidateFunc is a fake validate function with a call counter. It has
+// methods for create, update and delete validate functions which enables it to
+// be used as any of the types of validating functions.
+type fakeValidateFunc struct {
+	callCount     int
+	ErrorToReturn error
+}
+
+func (f *fakeValidateFunc) CreateFunc() ValidateCreateFunc {
+	return func(ctx context.Context, obj client.Object) error {
+		f.callCount++
+		return f.ErrorToReturn
+	}
+}
+
+func (f *fakeValidateFunc) UpdateFunc() ValidateUpdateFunc {
+	return func(ctx context.Context, obj client.Object, old client.Object) error {
+		f.callCount++
+		return f.ErrorToReturn
+	}
+}
+
+func (f *fakeValidateFunc) DeleteFunc() ValidateDeleteFunc {
+	return func(ctx context.Context, obj client.Object) error {
+		f.callCount++
+		return f.ErrorToReturn
+	}
+}
+
+func (f *fakeValidateFunc) Count() int {
+	return f.callCount
+}
+
+func (f *fakeValidateFunc) Reset() {
+	f.callCount = 0
+}

--- a/webhook/builder/doc.go
+++ b/webhook/builder/doc.go
@@ -1,0 +1,8 @@
+// Package builder is based on the controller-runtime webhook builder. It's
+// modified to support building webhooks for the unified admission controller
+// that supports creating webhooks for both native and custom resources.
+package builder
+
+import ctrl "sigs.k8s.io/controller-runtime"
+
+var log = ctrl.Log.WithName("webhook").WithName("builder")

--- a/webhook/builder/webhook.go
+++ b/webhook/builder/webhook.go
@@ -1,0 +1,111 @@
+package builder
+
+import (
+	"net/http"
+	"net/url"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	tkAdmission "github.com/darkowlzz/operator-toolkit/webhook/admission"
+)
+
+// Builder builds a Webhook.
+type Builder struct {
+	c            tkAdmission.Controller
+	mgr          manager.Manager
+	mutatePath   string
+	validatePath string
+}
+
+// WebhookManagedBy adds the manager to the builder.
+func WebhookManagedBy(m manager.Manager) *Builder {
+	return &Builder{mgr: m}
+}
+
+// MutatePath is the mutation webhook endpoint path to use when registering the
+// mutating webhook.
+func (blder *Builder) MutatePath(path string) *Builder {
+	blder.mutatePath = path
+	return blder
+}
+
+// ValidatePath is the validating webhook endpoint path to use when registering
+// the validating webhook.
+func (blder *Builder) ValidatePath(path string) *Builder {
+	blder.validatePath = path
+	return blder
+}
+
+// Complete builds the webhook.
+func (blder *Builder) Complete(c tkAdmission.Controller) error {
+	blder.c = c
+	return blder.registerWebhooks()
+}
+
+// registerWebhooks registers the defaulting and validating webhooks based on
+// their endpoint paths.
+func (blder *Builder) registerWebhooks() error {
+	if blder.mutatePath != "" {
+		blder.registerDefaultingWebhook()
+	}
+
+	if blder.validatePath != "" {
+		blder.registerValidatingWebhook()
+	}
+
+	return nil
+}
+
+// registerDefaultingWebhook builds and registers the defaulting webhook.
+func (blder *Builder) registerDefaultingWebhook() {
+	mwh := tkAdmission.DefaultingWebhookFor(blder.c)
+	if mwh != nil {
+		path := blder.mutatePath
+
+		// Checking if the path is already registered.
+		// If so, just skip it.
+		if !blder.isAlreadyHandled(path) {
+			log.Info("Registering a mutating webhook",
+				"controller", blder.c.Name(),
+				"path", path)
+			blder.mgr.GetWebhookServer().Register(path, mwh)
+		} else {
+			log.Info("Webhook path already registered, skipping registration",
+				"controller", blder.c.Name(),
+				"path", path)
+		}
+	}
+}
+
+// registerValidatingWebhook builds and registers the validating webhook.
+func (blder *Builder) registerValidatingWebhook() {
+	vwh := tkAdmission.ValidatingWebhookFor(blder.c)
+	if vwh != nil {
+		path := blder.validatePath
+
+		// Checking if the path is already registered.
+		// If so, just skip it.
+		if !blder.isAlreadyHandled(path) {
+			log.Info("Registering a validating webhook",
+				"controller", blder.c.Name(),
+				"path", path)
+			blder.mgr.GetWebhookServer().Register(path, vwh)
+		} else {
+			log.Info("Webhook path already registered, skipping registration",
+				"controller", blder.c.Name(),
+				"path", path)
+		}
+	}
+}
+
+// isAlreadyHandled checks if a webhook endpoint path is already registered.
+func (blder *Builder) isAlreadyHandled(path string) bool {
+	if blder.mgr.GetWebhookServer().WebhookMux == nil {
+		return false
+	}
+	h, p := blder.mgr.GetWebhookServer().WebhookMux.Handler(&http.Request{URL: &url.URL{Path: path}})
+	if p == path && h != nil {
+		return true
+	}
+	return false
+}

--- a/webhook/function/default.go
+++ b/webhook/function/default.go
@@ -1,0 +1,58 @@
+package function
+
+import (
+	"context"
+
+	"github.com/darkowlzz/operator-toolkit/discovery/cluster"
+	"github.com/darkowlzz/operator-toolkit/webhook/admission"
+	"k8s.io/client-go/discovery"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// AddLabels is a generic defaulter method for adding labels to any given
+// object.
+func AddLabels(cli client.Client, labels map[string]string) admission.DefaultFunc {
+	return func(ctx context.Context, obj client.Object) {
+		objLabels := obj.GetLabels()
+		if objLabels == nil {
+			objLabels = map[string]string{}
+		}
+		for k, v := range labels {
+			objLabels[k] = v
+		}
+		obj.SetLabels(objLabels)
+	}
+}
+
+// AddAnnotations is a generic defaulter method for adding annotations to any
+// given object.
+func AddAnnotations(cli client.Client, annotations map[string]string) admission.DefaultFunc {
+	return func(ctx context.Context, obj client.Object) {
+		objAnnot := obj.GetAnnotations()
+		if objAnnot == nil {
+			objAnnot = map[string]string{}
+		}
+		for k, v := range annotations {
+			objAnnot[k] = v
+		}
+		obj.SetAnnotations(objAnnot)
+	}
+}
+
+// AddClusterVersionAnnotation is a generic defaulter method for adding cluster
+// version info on an object's annotations. This requires a discovery client to
+// get the cluster info.
+func AddClusterVersionAnnotation(d discovery.DiscoveryInterface) admission.DefaultFunc {
+	return func(ctx context.Context, obj client.Object) {
+		version, err := cluster.NewFromDiscoveryClient(d).GetClusterVersion()
+		if err != nil {
+			return
+		}
+		objAnnot := obj.GetAnnotations()
+		if objAnnot == nil {
+			objAnnot = map[string]string{}
+		}
+		objAnnot["cluster-version"] = version
+		obj.SetAnnotations(objAnnot)
+	}
+}

--- a/webhook/function/doc.go
+++ b/webhook/function/doc.go
@@ -1,0 +1,5 @@
+// Package function contains common defaulting and validating functions that
+// can be imported and used in any admission controllers. It provides examples
+// of the functions, but more common and generic functions can also be
+// added to this package for reuse.
+package function

--- a/webhook/function/validate.go
+++ b/webhook/function/validate.go
@@ -1,0 +1,34 @@
+package function
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/darkowlzz/operator-toolkit/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ValidateLabels takes an object and a set of labels and validates the
+// object's labels based on the given set of labels. Unknown labels results in
+// failure.
+func ValidateLabels(obj client.Object, labels map[string]string) error {
+	for k := range obj.GetLabels() {
+		// Valid only if the key if found in the given set of labels.
+		if _, exists := labels[k]; !exists {
+			return fmt.Errorf("found unexpected label key %q", k)
+		}
+	}
+	return nil
+}
+
+func ValidateLabelsCreate(labels map[string]string) admission.ValidateCreateFunc {
+	return func(ctx context.Context, obj client.Object) error {
+		return ValidateLabels(obj, labels)
+	}
+}
+
+func ValidateLabelsUpdate(labels map[string]string) admission.ValidateUpdateFunc {
+	return func(ctx context.Context, obj client.Object, oldobj client.Object) error {
+		return ValidateLabels(obj, labels)
+	}
+}


### PR DESCRIPTION
This adds a new webhook admission controller that can be used to create
admission controllers for both k8s native and custom resources.
It also adds some new features allowing chaining of defaulter
and mutating functions, and perform common checks before starting the
defaulting and validating work.
The defaulting and validating functions used in the admission controller
handlers have examples in the webhook/function/ package, showing how to
create generic functions that can be shared and reused.