### PR TITLE
On case of duplication first image has to win during AddImages

### DIFF
--- a/declarative/kustomize/mutate.go
+++ b/declarative/kustomize/mutate.go
@@ -75,9 +75,9 @@ func AddImages(images []apitypes.Image) MutateFunc {
 		sequence := []string{}
 		for _, i := range images {
 			if _, exists := imageMap[i.Name]; !exists {
+				imageMap[i.Name] = i
 				sequence = append(sequence, i.Name)
 			}
-			imageMap[i.Name] = i
 		}
 		// Populate the unique images in the recorded sequence.
 		for _, iName := range sequence {

--- a/declarative/kustomize/mutate_test.go
+++ b/declarative/kustomize/mutate_test.go
@@ -187,8 +187,8 @@ images:
   newName: fooapp/appA
   newTag: "33"
 - name: someAppA
-  newName: barexample/AppZ
-  newTag: v20
+  newName: fooexample/AppY
+  newTag: v10
 kind: Kustomization
 `,
 		},


### PR DESCRIPTION
Before this change `imageMap[i.Name]` was overwritten each time during the iteration, so not the first (as comment suggested) but the last element was selected.