### PR TITLE
OperandOrder.Reverse() avoid reversing the original OperandOrder

### DIFF
--- a/operator/v1/dag/dag_test.go
+++ b/operator/v1/dag/dag_test.go
@@ -87,4 +87,8 @@ func TestDAG(t *testing.T) {
 	if reverseOrder.String() != expectedReverseResult {
 		t.Errorf("unexpected reverse results:\n\t(WNT) %q\n\t(GOT) %q", expectedReverseResult, reverseOrder)
 	}
+
+	if ordered.String() != expectedResult {
+		t.Errorf("unexpected results after reverse:\n\t(WNT) %q\n\t(GOT) %q", expectedResult, ordered)
+	}
 }

--- a/operator/v1/operand/order.go
+++ b/operator/v1/operand/order.go
@@ -41,10 +41,11 @@ func (o OperandOrder) String() string {
 // Reverse returns the OperandOrder in reverse order.
 func (o OperandOrder) Reverse() OperandOrder {
 	// Refer: https://github.com/golang/go/wiki/SliceTricks#reversing
+	r := make(OperandOrder, len(o))
 	for left, right := 0, len(o)-1; left < right; left, right = left+1, right-1 {
-		o[left], o[right] = o[right], o[left]
+		r[left], r[right] = o[right], o[left]
 	}
-	return o
+	return r
 }
 
 // StepRequeueStrategy returns the requeue strategy of a step. By default, the


### PR DESCRIPTION
 OperandOrder.Reverse() should avoid reversing the original OperandOrder.